### PR TITLE
Fix for #182: Last is always null

### DIFF
--- a/pkg/plot/plot.go
+++ b/pkg/plot/plot.go
@@ -115,27 +115,27 @@ func (series *Series) Scale(factor Value) {
 // into the Summary map.
 func (series *Series) Summarize(percentiles []float64) {
 	var (
-		min, max, total Value
+		min, max, total, current Value
 		nValidPlots     int64
 		nPlots          = len(series.Plots)
 	)
 
 	if nPlots > 0 {
 		min = series.Plots[0].Value
-		series.Summary["last"] = series.Plots[nPlots-1].Value
 	}
 
 	for i := range series.Plots {
-		if !series.Plots[i].Value.IsNaN() && series.Plots[i].Value < min || min.IsNaN() {
-			min = series.Plots[i].Value
-		}
-
-		if series.Plots[i].Value > max {
-			max = series.Plots[i].Value
-		}
-
 		if !series.Plots[i].Value.IsNaN() {
-			total += series.Plots[i].Value
+			current = series.Plots[i].Value
+			if current < min || min.IsNaN() {
+				min = series.Plots[i].Value
+			}
+
+			if current > max {
+				max = current
+			}
+
+			total += current
 			nValidPlots++
 		}
 	}
@@ -147,6 +147,7 @@ func (series *Series) Summarize(percentiles []float64) {
 	series.Summary["min"] = min
 	series.Summary["max"] = max
 	series.Summary["avg"] = total / Value(nValidPlots)
+	series.Summary["last"] = current
 
 	if len(percentiles) > 0 {
 		series.Percentiles(percentiles)


### PR DESCRIPTION
I've stumbled over this problem when fiddling around with the multi-axes feature.
So.. Here's a fix for Issue #182. 

Vincent, feel free do dump this PR if you already have a better idea.
The commit message doesn't mention the issue in https://github.com/ziutek/rrd/pull/13, as even if this gets fixed, cached RRD writes will not show up as last entry reliably.

Especially with asynchronous writing to RRD files, plot won't be able to
get the latest data. Instead the graph will end some seconds before. Now,
the "last" value is actually the last value shown in the graph.
But as the code show
